### PR TITLE
Add tests for accessors and init weights method

### DIFF
--- a/src/AI-LinearModels-Tests/AIAbstractLinearModelTest.class.st
+++ b/src/AI-LinearModels-Tests/AIAbstractLinearModelTest.class.st
@@ -109,6 +109,16 @@ AIAbstractLinearModelTest >> testInconsistentMaxIterations [
 ]
 
 { #category : #tests }
+AIAbstractLinearModelTest >> testInitializeWeightsToZeroOfSize [
+
+	| expectedInitWeigths |
+	expectedInitWeigths := #(0 0 0).
+	model initializeWeightsToZeroOfSize: 3.
+	
+	self assert: model weights equals: expectedInitWeigths   
+]
+
+{ #category : #tests }
 AIAbstractLinearModelTest >> testLearningRateIsInitialized [
 
 	self

--- a/src/AI-LinearModels-Tests/AIAbstractLinearModelTest.class.st
+++ b/src/AI-LinearModels-Tests/AIAbstractLinearModelTest.class.st
@@ -109,6 +109,26 @@ AIAbstractLinearModelTest >> testInconsistentMaxIterations [
 ]
 
 { #category : #tests }
+AIAbstractLinearModelTest >> testLearningRateIsInitialized [
+
+	self
+		assert: model learningRate 
+		equals: model class defaultLearningRate 
+]
+
+{ #category : #tests }
+AIAbstractLinearModelTest >> testMaxIterationsIsInitialized [
+
+	self assert: model maxIterations equals: model class defaultMaxIterations 
+]
+
+{ #category : #tests }
+AIAbstractLinearModelTest >> testPerformedIterationsIsInitialized [
+
+	self assert: model performedIterations equals: nil
+]
+
+{ #category : #tests }
 AIAbstractLinearModelTest >> testPredictionWithNonFittedModel [
 
 	| input output |


### PR DESCRIPTION
@jordanmontt I added tests for the getters learningRate, maxIterations and performedIterations as well as a test for the method `initializeWeightsToZeroOfSize: aNumber`